### PR TITLE
fix: update tiny-secp256k1 to 1.1.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "ripemd160": "2",
     "semver": "^7.3.5",
     "sha.js": "2",
-    "tiny-secp256k1": "1.1.6",
+    "tiny-secp256k1": "1.1.7",
     "typescript": "^5.5.4",
     "varuint-bitcoin": "1.1.2"
   },


### PR DESCRIPTION
See https://github.com/bitcoinjs/tiny-secp256k1/pull/140 (full thread)

Note: it doesn't look like that `@blooo/hw-app-acre` was affected, the usage here seems safe